### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 16.5.0

### DIFF
--- a/ConsoleApp1/ConsoleApp1.csproj
+++ b/ConsoleApp1/ConsoleApp1.csproj
@@ -11,6 +11,6 @@
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	    <PrivateAssets>all</PrivateAssets>
 	  </PackageReference>
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.NET.Test.Sdk` to `16.5.0` from `15.9.0`
`Microsoft.NET.Test.Sdk 16.5.0` was published at `2020-02-05T08:34:13Z`, 4 days ago

1 project update:
Updated `ConsoleApp1\ConsoleApp1.csproj` to `Microsoft.NET.Test.Sdk` `16.5.0` from `15.9.0`

[Microsoft.NET.Test.Sdk 16.5.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.5.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
